### PR TITLE
eslint errors and refactor header

### DIFF
--- a/template/.editorconfig
+++ b/template/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/template/package.json
+++ b/template/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint src"
   },
   "eslintConfig": {
-    "extends": "eslint-config-synacor",
+    "extends": ["eslint-config-synacor", "prettier"],
     "rules": {
       "react/sort-comp": "off",
       "react/prefer-stateless-function": "off"
@@ -21,8 +21,11 @@
   "devDependencies": {
     "eslint": "^4.5.0",
     "eslint-config-synacor": "^1.1.0",
+    "eslint-config-prettier": "^2.7.0",
+    "eslint-plugin-prettier": "^2.3.0",
     "if-env": "^1.0.0",
-    "preact-cli": "^2.0.0"
+    "preact-cli": "^2.0.0",
+    "prettier": "^1.8.0"
   },
   "dependencies": {
     "preact": "^8.2.1",

--- a/template/package.json
+++ b/template/package.json
@@ -8,7 +8,7 @@
     "build": "preact build",
     "serve": "preact build && preact serve",
     "dev": "preact watch",
-    "test": "eslint src && preact test"
+    "lint": "eslint src"
   },
   "eslintConfig": {
     "extends": "eslint-config-synacor",

--- a/template/package.json
+++ b/template/package.json
@@ -11,7 +11,11 @@
     "test": "eslint src && preact test"
   },
   "eslintConfig": {
-    "extends": "eslint-config-synacor"
+    "extends": "eslint-config-synacor",
+    "rules": {
+      "react/sort-comp": "off",
+      "react/prefer-stateless-function": "off"
+    }
   },
   "eslintIgnore": ["build/*"],
   "devDependencies": {

--- a/template/src/components/header/index.js
+++ b/template/src/components/header/index.js
@@ -10,71 +10,89 @@ import 'preact-material-components/Dialog/style.css';
 import 'preact-material-components/Drawer/style.css';
 import 'preact-material-components/List/style.css';
 import 'preact-material-components/Toolbar/style.css';
+/* eslint-disable no-unused-vars */
 import style from './style';
 
 export default class Header extends Component {
-	closeDrawer(){
-		this.drawer.MDComponent.open = false;
-		this.state = {
-			darkThemeEnabled: false
-		};
-	}
-	render() {
-		return (
-			<div>
-				<Toolbar className="toolbar">
-					<Toolbar.Row>
-						<Toolbar.Section align-start={true}>
-							<Toolbar.Icon menu={true} onClick={() => {
-								this.drawer.MDComponent.open = true;
-							}}>menu</Toolbar.Icon>
-							<Toolbar.Title>
-								Preact app
-							</Toolbar.Title>
-						</Toolbar.Section>
-						<Toolbar.Section align-end={true} onClick={()=>{
-							this.dialog.MDComponent.show();
-						}}>
-							<Toolbar.Icon>settings</Toolbar.Icon>
-						</Toolbar.Section>
-					</Toolbar.Row>
-				</Toolbar>
-				<Drawer.TemporaryDrawer ref={drawer=>{this.drawer = drawer;}} >
-					<Drawer.TemporaryDrawerContent>
-						<List>
-							<List.LinkItem onClick={()=>{route('/'); this.closeDrawer();}}>
-								<List.ItemIcon>home</List.ItemIcon>
-									Home
-							</List.LinkItem>
-							<List.LinkItem onClick={()=>{route('/profile'); this.closeDrawer();}}>
-								<List.ItemIcon>account_circle</List.ItemIcon>
-									Profile
-							</List.LinkItem>
-						</List>
-					</Drawer.TemporaryDrawerContent>
-				</Drawer.TemporaryDrawer>
-				<Dialog ref={dialog=>{this.dialog=dialog;}}>
+  closeDrawer() {
+    this.drawer.MDComponent.open = false;
+    this.state = {
+      darkThemeEnabled: false,
+    };
+  }
+
+  openDrawer = () => (this.drawer.MDComponent.open = true);
+
+  openSettings = () => this.dialog.MDComponent.show();
+
+  drawerRef = drawer => (this.drawer = drawer);
+  dialogRef = dialog => (this.dialog = dialog);
+
+  linkTo = path => () => {
+    route(path);
+    this.closeDrawer();
+  };
+
+  goHome = this.linkTo('/');
+  goToMyProfile = this.linkTo('/profile');
+
+  toggleDarkTheme() {
+    this.setState(
+      {
+        darkThemeEnabled: !this.state.darkThemeEnabled,
+      },
+      () => {
+        if (this.state.darkThemeEnabled) {
+          document.body.classList.add('mdc-theme--dark');
+        } else {
+          document.body.classList.remove('mdc-theme--dark');
+        }
+      }
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        <Toolbar className="toolbar">
+          <Toolbar.Row>
+            <Toolbar.Section align-start>
+              <Toolbar.Icon menu onClick={this.openDrawer}>
+                menu
+              </Toolbar.Icon>
+              <Toolbar.Title>Preact app</Toolbar.Title>
+            </Toolbar.Section>
+            <Toolbar.Section align-end onClick={this.openSettings}>
+              <Toolbar.Icon>settings</Toolbar.Icon>
+            </Toolbar.Section>
+          </Toolbar.Row>
+        </Toolbar>
+        <Drawer.TemporaryDrawer ref={this.drawerRef}>
+          <Drawer.TemporaryDrawerContent>
+            <List>
+              <List.LinkItem onClick={this.goHome}>
+                <List.ItemIcon>home</List.ItemIcon>
+                Home
+              </List.LinkItem>
+              <List.LinkItem onClick={this.goToMyProfile}>
+                <List.ItemIcon>account_circle</List.ItemIcon>
+                Profile
+              </List.LinkItem>
+            </List>
+          </Drawer.TemporaryDrawerContent>
+        </Drawer.TemporaryDrawer>
+        <Dialog ref={this.dialogRef}>
           <Dialog.Header>Settings</Dialog.Header>
           <Dialog.Body>
-						<div>
-							Enable dark theme <Switch onClick={()=>{
-								this.setState({
-									darkThemeEnabled: !this.state.darkThemeEnabled
-								},() => {
-									if(this.state.darkThemeEnabled) {
-										document.body.classList.add('mdc-theme--dark');
-									} else {
-										document.body.classList.remove('mdc-theme--dark');
-									}
-								});
-							}}/>
-						</div>
+            <div>
+              Enable dark theme <Switch onClick={this.toggleDarkTheme} />
+            </div>
           </Dialog.Body>
           <Dialog.Footer>
-            <Dialog.FooterButton accept={true}>okay</Dialog.FooterButton>
+            <Dialog.FooterButton accept>okay</Dialog.FooterButton>
           </Dialog.Footer>
         </Dialog>
-			</div>
-		);
-	}
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
Here's an alternate fix for eslint errors. I refactored the Header component to define it's functions outside of the render method and disabled the no-unused-vars rule for just the one line where we have a violation. It has a bunch of spacing-related linting errors that for some reason I couldn't get eslint to fix.