### PR TITLE
Shrink the ⚙

### DIFF
--- a/template/src/components/header/index.js
+++ b/template/src/components/header/index.js
@@ -62,7 +62,7 @@ export default class Header extends Component {
 							</Toolbar.Icon>
 							<Toolbar.Title>Preact app</Toolbar.Title>
 						</Toolbar.Section>
-						<Toolbar.Section align-end onClick={this.openSettings}>
+						<Toolbar.Section align-end shrink-to-fit onClick={this.openSettings}>
 							<Toolbar.Icon>settings</Toolbar.Icon>
 						</Toolbar.Section>
 					</Toolbar.Row>
@@ -87,7 +87,7 @@ export default class Header extends Component {
 						</div>
 					</Dialog.Body>
 					<Dialog.Footer>
-						<Dialog.FooterButton accept>okay</Dialog.FooterButton>
+						<Dialog.FooterButton accept>OK</Dialog.FooterButton>
 					</Dialog.Footer>
 				</Dialog>
 			</div>


### PR DESCRIPTION
Otherwise we get this:
![image](https://user-images.githubusercontent.com/33569/42802387-a5d7849c-8957-11e8-8001-3074f669ee33.png)
