### PR TITLE
<TopAppBar className="topappbar"> rather than "toolbar"

### DIFF
--- a/template/src/components/header/index.js
+++ b/template/src/components/header/index.js
@@ -55,7 +55,7 @@ export default class Header extends Component {
 		console.log(props.selectedRoute);
 		return (
 			<div>
-				<TopAppBar className="toolbar">
+				<TopAppBar className="topappbar">
 					<TopAppBar.Row>
 						<TopAppBar.Section align-start>
 							<TopAppBar.Icon menu onClick={this.openDrawer}>


### PR DESCRIPTION
Per https://material.preactjs.com/component/top-app-bar/, though any class name, even `foo`, has the same visual result.