### PR TITLE
Use per-env instead if-env that's deprecated

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -4,7 +4,9 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "start": "if-env NODE_ENV=production && npm run -s serve || npm run -s dev",
+    "start": "per-env",
+    "start:development": "npm run -s dev",
+    "start:production": "npm run -s serve",
     "build": "preact build",
     "serve": "preact build && preact serve",
     "dev": "preact watch",
@@ -23,8 +25,8 @@
   "devDependencies": {
     "eslint": "^4.5.0",
     "eslint-config-synacor": "^1.1.0",
-    "if-env": "^1.0.0",
-    "preact-cli": "^2.0.0"
+    "preact-cli": "^2.0.0",
+    "per-env": "^1.0.2"
   },
   "dependencies": {
     "preact": "^8.2.1",


### PR DESCRIPTION
Today, we're using `if-env` to run commands based in `env`, but it's deprecated.
 
This PR replaces it to `per-env`, that is suggested in `if-env`: https://github.com/ericclemmons/if-env